### PR TITLE
Update tutorials/introduction.html

### DIFF
--- a/tutorials/introduction.html
+++ b/tutorials/introduction.html
@@ -66,12 +66,12 @@ The diagram shows two active maps: <code>d2:s1 -&gt; d3:s3</code> (labelled <cod
 <p>Detailed tutorials are provided for using libmapper in the following programming languages and environments:</p>
 
 <ul>
-<li><a href="./tutorial_c.html">C</a></li>
-<li><a href="./tutorial_cpp.html">C++</a></li>
-<li><a href="./tutorial_python.html">Python</a></li>
-<li><a href="./tutorial_java.html">Java</a></li>
-<li><a href="./tutorial_maxmsp_multiobj.html">Max/MSP</a></li>
-<li><a href="./tutorial_pure_data.html">Puredata</a></li>
+<li><a href="./c.html">C</a></li>
+<li><a href="./cpp.html">C++</a></li>
+<li><a href="./python.html">Python</a></li>
+<li><a href="./java.html">Java</a></li>
+<li><a href="./maxmsp_multiobj.html">Max/MSP</a></li>
+<li><a href="./pure_data.html">Puredata</a></li>
 </ul>
 
 <!--end of exported tutorial-->


### PR DESCRIPTION
Fixes broken anchor tags to each of the language specific tutorials in footer of the `tutorials/introduction.html`.  The upper nav-bar works great, but these links led to 404! :smile: 